### PR TITLE
Removed 'am' line

### DIFF
--- a/utils/beekeep/src/json_write_raw.c
+++ b/utils/beekeep/src/json_write_raw.c
@@ -176,7 +176,7 @@ static json_t* net_write_json_presets(void) {
   json_t* o;
   json_t* p;
   int i, j;
-am
+
   json_object_set(pres, "count", json_integer(NET_PRESETS_MAX));
   m = json_array();
 


### PR DESCRIPTION
I removed what looks like a typo in order to get beekeep to compile; it still isn't compiling, but it gets past this error now.
