### PR TITLE
Remove 'am' line

### DIFF
--- a/utils/beekeep/src/json_write_raw.c
+++ b/utils/beekeep/src/json_write_raw.c
@@ -176,7 +176,7 @@ static json_t* net_write_json_presets(void) {
   json_t* o;
   json_t* p;
   int i, j;
-am
+
   json_object_set(pres, "count", json_integer(NET_PRESETS_MAX));
   m = json_array();
 


### PR DESCRIPTION
OK, here's the same pull request from the dev branch. I've successfully compiled bees; the beekeep compilation now fails at this point:

gcc ../../apps/bees/src/app_timers.o ../../apps/bees/src/net.o ../../apps/bees/src/net_midi.o ../../apps/bees/src/net_monome.o ../../apps/bees/src/net_poll.o ../../apps/bees/src/op.o ../../apps/bees/src/op_math.o ../../apps/bees/src/param.o ../../apps/bees/src/pages.o ../../apps/bees/src/pickle.o ../../apps/bees/src/play.o ../../apps/bees/src/preset.o ../../apps/bees/src/render.o ../../apps/bees/src/param_scaler.o ../../apps/bees/src/scene.o ../../apps/bees/src/util.o ../../apps/bees/src/ops/op_add.o ../../apps/bees/src/ops/op_accum.o ../../apps/bees/src/ops/op_adc.o ../../apps/bees/src/ops/op_bits.o ../../apps/bees/src/ops/op_div.o ../../apps/bees/src/ops/op_enc.o ../../apps/bees/src/ops/op_gate.o ../../apps/bees/src/ops/op_history.o ../../apps/bees/src/ops/op_is.o ../../apps/bees/src/ops/op_life.o ../../apps/bees/src/ops/op_list2.o ../../apps/bees/src/ops/op_list8.o ../../apps/bees/src/ops/op_logic.o ../../apps/bees/src/ops/op_metro.o ../../apps/bees/src/ops/op_midi_note.o ../../apps/bees/src/ops/op_mod.o ../../apps/bees/src/ops/op_mul.o ../../apps/bees/src/ops/op_monome_grid_raw.o ../../apps/bees/src/ops/op_preset.o ../../apps/bees/src/ops/op_split.o ../../apps/bees/src/ops/op_sub.o ../../apps/bees/src/ops/op_sw.o ../../apps/bees/src/ops/op_timer.o ../../apps/bees/src/ops/op_thresh.o ../../apps/bees/src/ops/op_tog.o ../../apps/bees/src/ops/op_random.o ../../apps/bees/src/pages/page_dsp.o ../../apps/bees/src/pages/page_gathered.o ../../apps/bees/src/pages/page_ins.o ../../apps/bees/src/pages/page_ops.o ../../apps/bees/src/pages/page_outs.o ../../apps/bees/src/pages/page_play.o ../../apps/bees/src/pages/page_presets.o ../../apps/bees/src/pages/page_scenes.o ../../apps/bees/src/scalers/scaler_amp.o ../../apps/bees/src/scalers/scaler_bool.o ../../apps/bees/src/scalers/scaler_fix.o ../../apps/bees/src/scalers/scaler_integrator.o ../../apps/bees/src/scalers/scaler_note.o ../../apps/bees/src/scalers/scaler_svf_fc.o src/app_beekeep.o src/flash_beekeep.o src/files.o src/handler.o src/main.o src/json_read_raw.o src/json_write_raw.o src/json_read_max.o src/json_write_max.o ../avr32_sim/src/adc.o ../avr32_sim/src/app.o ../avr32_sim/src/bfin.o ../avr32_sim/src/control.o ../avr32_sim/src/delay.o ../avr32_sim/src/events.o ../avr32_sim/src/encoders.o ../avr32_sim/src/filesystem.o ../avr32_sim/src/flash.o ../avr32_sim/src/font.o ../avr32_sim/src/i2c.o ../avr32_sim/src/init.o ../avr32_sim/src/interrupts.o ../avr32_sim/src/memory.o ../avr32_sim/src/monome.o ../avr32_sim/src/print_funcs.o ../avr32_sim/src/region.o ../avr32_sim/src/screen.o ../avr32_sim/src/serial.o ../avr32_sim/src/simple_string.o ../avr32_sim/src/switches.o ../avr32_sim/src/timers.o ../avr32_sim/src/usb.o ../avr32_sim/src/usb/midi/midi.o ../avr32_sim/src/usb/ftdi/ftdi.o ../avr32_sim/src/fonts/ume_tgo5_18.o ../avr32_sim/src/fix.o ../avr32_sim/src/libfixmath/fix16.o -g -I../../apps/bees -I../../apps/bees/src -I../../apps/bees/../../common -I../avr32_sim -I../avr32_sim/src -I../avr32_sim/src/usb -I../avr32_sim/src/usb/midi -I../avr32_sim/src/usb/ftdi -I../avr32_sim/src/usb/hid -I../avr32_sim/src/usb/mouse -I../avr32_sim/src/usb/hub -std=gnu99 -o beekeep-0.4.3 -ljansson
../../apps/bees/src/net.o: In function `net_activate':
/home/vagrant/aleph/utils/beekeep/../../apps/bees/src/net.c:348: undefined reference to`opPlay'
../../apps/bees/src/op.o:(.rodata+0x430): undefined reference to `op_bignum_init'
../../apps/bees/src/op.o:(.rodata+0x438): undefined reference to`op_bignum_deinit'
../../apps/bees/src/op.o:(.rodata+0x450): undefined reference to `op_screen_init'
../../apps/bees/src/op.o:(.rodata+0x458): undefined reference to`op_screen_deinit'
../../apps/bees/src/op.o:(.rodata+0x470): undefined reference to `op_split4_init'
../../apps/bees/src/op.o:(.rodata+0x490): undefined reference to`op_delay_init'
../../apps/bees/src/op.o:(.rodata+0x4b0): undefined reference to `op_route_init'
collect2: ld returned 1 exit status
make: **\* [target] Error 1
