### PR TITLE
git status output was rather voluminous, ignore build artifacts by default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+*.o
+*.d
+*.ldr
+*.hex
+*.elf
+*.bin
+*.lss
+*.map
+*.sym
+*.dsc
+*_desc_build


### PR DESCRIPTION
Adds a .gitignore file so that the build artifacts (.o files for example) are ignored by default.
