### PR TITLE
bees: added change operator

### DIFF
--- a/apps/bees/config.mk
+++ b/apps/bees/config.mk
@@ -48,6 +48,7 @@ CSRCS += \
 	$(APP_DIR)/src/ops/op_bignum.c \
 	$(APP_DIR)/src/ops/op_bits.c \
 	$(APP_DIR)/src/ops/op_cascades.c \
+	$(APP_DIR)/src/ops/op_change.c \
 	$(APP_DIR)/src/ops/op_delay.c \
 	$(APP_DIR)/src/ops/op_div.c \
 	$(APP_DIR)/src/ops/op_divr.c \

--- a/apps/bees/src/op.c
+++ b/apps/bees/src/op.c
@@ -27,6 +27,7 @@ const op_id_t userOpTypes[NUM_USER_OP_TYPES] = {
   eOpBars,
   eOpBignum,
   eOpBits,
+  eOpChange,
   eOpDelay,
   eOpDiv,
   eOpDivr,
@@ -86,22 +87,22 @@ const op_desc_t op_registry[numOpClasses] = {
     .size = sizeof(op_add_t) ,
     .init = &op_add_init,
     .deinit = NULL
-  } , {
+  }, {
     .name = "MUL",
     .size = sizeof(op_mul_t) ,
     .init = &op_mul_init,
     .deinit = NULL
-  } , {
+  }, {
     .name = "GATE",
     .size = sizeof(op_gate_t), 
     .init = &op_gate_init,
     .deinit = NULL
-  } , {
+  }, {
     .name = "GRID",
     .size = sizeof(op_mgrid_raw_t),
     .init = &op_mgrid_raw_init,
     .deinit = &op_mgrid_raw_deinit
-  } , {
+  }, {
     .name = "MIDINOTE",
     .size = sizeof(op_midi_note_t),
     .init = &op_midi_note_init,
@@ -206,7 +207,7 @@ const op_desc_t op_registry[numOpClasses] = {
     .size = sizeof(op_bignum_t),
     .init = &op_bignum_init,
     .deinit = &op_bignum_deinit
-    }, {
+  }, {
     .name = "SCREEN",
     .size = sizeof(op_screen_t),
     .init = &op_screen_init,
@@ -261,50 +262,50 @@ const op_desc_t op_registry[numOpClasses] = {
     .size = sizeof(op_bars_t),
     .init = &op_bars_init,
     .deinit = &op_bars_deinit   
-  },
-  {
+  }, {
     .name = "SERIAL",
     .size = sizeof(op_serial_t),
     .init = &op_serial_init,
     .deinit = &op_serial_deinit   
-  },
-  {
+  }, {
     .name = "HID",
     .size = sizeof(op_hid_word_t),
     .init = &op_hid_word_init,
     .deinit = &op_hid_word_deinit   
-  },
-  {
+  }, {
     .name = "WW",
     .size = sizeof(op_ww_t),
     .init = &op_ww_init,
     .deinit = &op_ww_deinit   
-  },
-  {
+  }, {
     .name = "ARC",
     .size = sizeof(op_marc_t),
     .init = &op_marc_init,
     .deinit = &op_marc_deinit
-  },
-  {
+  }, {
     .name = "FADE",
     .size = sizeof(op_fade_t),
     .init = &op_fade_init,
     .deinit = NULL
-  },  {
+  }, {
     .name = "DIVR",
     .size = sizeof(op_divr_t),
     .init = &op_divr_init,
     .deinit = NULL
-  },  {
+  }, {
     .name = "SHL",
     .size = sizeof(op_shl_t),
     .init = &op_shl_init,
     .deinit = NULL
-  },  {
+  }, {
     .name = "SHR",
     .size = sizeof(op_shr_t),
     .init = &op_shr_init,
+    .deinit = NULL
+  }, {
+    .name = "CHANGE",
+    .size = sizeof(op_change_t),
+    .init = &op_change_init,
     .deinit = NULL
   },
 };

--- a/apps/bees/src/op.h
+++ b/apps/bees/src/op.h
@@ -20,7 +20,7 @@
 #define OP_OUTS_MAX 32
 
 // const array of user-creatable operator types
-#define NUM_USER_OP_TYPES 42
+#define NUM_USER_OP_TYPES 43
 
 //---- flags enum; 
 typedef enum {
@@ -85,6 +85,7 @@ typedef enum {
   eOpDivr,
   eOpShl,
   eOpShr,
+  eOpChange,
   //  eOpMidiBend,
   //  eOpMidiTouch,
   numOpClasses // dummy/count 

--- a/apps/bees/src/op_derived.h
+++ b/apps/bees/src/op_derived.h
@@ -16,6 +16,7 @@
 #include "ops/op_bignum.h"
 #include "ops/op_bits.h"
 #include "ops/op_cascades.h"
+#include "ops/op_change.h"
 #include "ops/op_delay.h"
 #include "ops/op_div.h"
 #include "ops/op_divr.h"

--- a/apps/bees/src/ops/op_change.c
+++ b/apps/bees/src/ops/op_change.c
@@ -1,0 +1,75 @@
+#include "net_protected.h"
+#include "op_change.h"
+
+//-------------------------------------------------
+//----- static function declaration
+static void op_change_in_val(op_change_t* op, const io_t v);
+static void op_change_in_last(op_change_t* op, const io_t v);
+
+// pickle / unpickle
+static u8* op_change_pickle(op_change_t* op, u8* dst);
+static const u8* op_change_unpickle(op_change_t* op, const u8* src);
+
+
+//-------------------------------------------------
+//----- static vars
+static op_in_fn op_change_in_fn[2] = {
+  (op_in_fn)&op_change_in_val,
+  (op_in_fn)&op_change_in_last,
+};
+
+static const char* op_change_instring  = "VAL\0    LAST\0   ";
+static const char* op_change_outstring = "VAL\0    ";
+static const char* op_change_opstring  = "CHANGE";
+
+//-------------------------------------------------
+//----- external function definitions
+void op_change_init(void* mem) {
+  op_change_t* op = (op_change_t*)mem;
+  op->super.numInputs = 2;
+  op->super.numOutputs = 1;
+  op->outs[0] = -1;
+
+  op->super.in_fn = op_change_in_fn;
+  op->super.pickle = (op_pickle_fn) (&op_change_pickle);
+  op->super.unpickle = (op_unpickle_fn) (&op_change_unpickle);
+
+  op->super.in_val = op->in_val;
+  op->super.out = op->outs;
+  op->super.opString = op_change_opstring;
+  op->super.inString = op_change_instring;
+  op->super.outString = op_change_outstring;
+  op->super.type = eOpChange;
+  op->in_val[0] = &(op->val);
+  op->in_val[1] = &(op->last);
+
+  op->val = 0;
+  op->last = 0;
+}
+
+//-------------------------------------------------
+//----- static function definitions
+static void op_change_in_val(op_change_t* op, const io_t v) {
+  op->val = v;
+  if (v != op->last) {
+    op->last = op->val;
+    net_activate(op->outs[0], op->val, op);
+  }
+}
+
+static void op_change_in_last(op_change_t* op, const io_t v) {
+  op->last = v;
+}
+
+// pickle / unpickle
+u8* op_change_pickle(op_change_t* op, u8* dst) {
+  dst = pickle_io(op->last, dst);
+  dst = pickle_io(op->val, dst);
+  return dst;
+}
+
+const u8* op_change_unpickle(op_change_t* op, const u8* src ) {
+  src = unpickle_io(src, &(op->last));
+  src = unpickle_io(src, &(op->val));
+  return src;
+}

--- a/apps/bees/src/ops/op_change.h
+++ b/apps/bees/src/ops/op_change.h
@@ -1,0 +1,22 @@
+#ifndef _op_change_H_
+#define _op_change_H_
+
+#include "op.h"
+#include "op_math.h"
+#include "types.h"
+
+//--- op_change_t : filter repetition
+typedef struct op_change_struct {
+  op_t super;
+
+  volatile io_t val;
+  volatile io_t last;
+  volatile io_t* in_val[2];
+
+  op_out_t outs[1];
+} op_change_t;
+
+void op_change_init(void* mem);
+
+
+#endif // header guard


### PR DESCRIPTION
also consistent formatting in op_registry

`change` is a trivial operator (very) loosely patterned after the change object in max. it seemed at the time an easier way of filtering out repetition than using the `is` op along with other ops.
