### PR TITLE
bees: ensure bfin ready before querying module

### DIFF
--- a/apps/bees/src/files.c
+++ b/apps/bees/src/files.c
@@ -214,7 +214,6 @@ u8 files_load_dsp_name(const char* name) {
       scene_set_module_name(name);
       ///////////////////////////
 
-      
       ret = files_load_desc(name);
       //???
       ret = 1;
@@ -526,19 +525,37 @@ extern u8 files_load_desc(const char* name) {
 
   app_pause();
 
+  print_dbg("\r\n files_load_desc(): name = ");
+  print_dbg(name);
+
   strcat(path, name);
   strip_ext(path);
   strcat(path, ".dsc");
 
+  print_dbg("\r\n ...path = ");
+  print_dbg(path);
+
 
   fp = fl_fopen(path, "r");
   if(fp == NULL) {
+    print_dbg("\r\n file_load_desc(): fl_fopen(...) => NULL");
     ret = 1;
   } else {
 
     // get number of parameters
     fake_fread(nbuf, 4, fp);
-    unpickle_32(nbuf, (u32*)&nparams); 
+    unpickle_32(nbuf, (u32*)&nparams);
+
+    print_dbg("\r\n file_load_desc(): nparams = 0x");
+    print_dbg_hex(nparams);
+
+    // on boot the bfin is put back into spi slave mode before the
+    // module_init() is called. since net_add_param() below ultimately
+    // gets the default values from the module via spi we wait for the
+    // bfin to be ready thus ensuring that module_init() has actually
+    // had time to sets the parameter defaults.
+    print_dbg("\r\n file_load_desc(): waiting for bfin to be ready before quering parameters");
+    bfin_wait_ready();
 
     /// loop over params
     if(nparams > 0) {

--- a/apps/bees/src/pages/page_dsp.c
+++ b/apps/bees/src/pages/page_dsp.c
@@ -160,8 +160,6 @@ void handle_key_0(s32 val) {
 
     bfin_wait_ready();
 
-    scene_query_module();
-
     //// FIXME: use .dsc, file_load_dsp calls directly
     //    net_report_params();
    


### PR DESCRIPTION
this change addresses a race condition which can occur when explicitly loading modules into a clean bees scene.

the dsp module main() places the bfin into spi slave mode before calling module_init() which allows commands from the avr to be processed before module_init() has completed. if module_init() does a significant amount of work (i.e. clearing buffers) before setting the module's initial parameter values then calls to functions like net_add_param() which read back parameter values from the bfin end up receiving uninitialized parameter values (whatever happened to be in SDRAM on bfin).
