### PR TITLE
removed aleph- prefix from waves, lines, dsyn modules

### DIFF
--- a/modules/dsyn/dsyn.c
+++ b/modules/dsyn/dsyn.c
@@ -180,7 +180,7 @@ void module_init(void) {
   dbgFile = fopen( "drums_dbg.txt", "w");
 #endif
   gModuleData = &(data->super);
-  strcpy(gModuleData->name, "aleph-dsyn");
+  strcpy(gModuleData->name, "dsyn");
 
   gModuleData->paramData = data->mParamData;
   gModuleData->numParams = eParamNumParams;

--- a/modules/lines/lines.c
+++ b/modules/lines/lines.c
@@ -259,7 +259,7 @@ void module_init(void) {
   pLinesData = (linesData*)SDRAM_ADDRESS;
   
   gModuleData = &(pLinesData->super);
-  strcpy(gModuleData->name, "aleph-lines");
+  strcpy(gModuleData->name, "lines");
 
   gModuleData->paramData = (ParamData*)pLinesData->mParamData;
   gModuleData->numParams = eParamNumParams;

--- a/modules/waves/waves.c
+++ b/modules/waves/waves.c
@@ -260,7 +260,7 @@ void module_init(void) {
   data = (wavesData * )SDRAM_ADDRESS;
   // initialize moduleData superclass for core routines
   gModuleData = &(data->super);
-  strcpy(gModuleData->name, "aleph-waves");
+  strcpy(gModuleData->name, "waves");
   gModuleData->paramData = data->mParamData;
   gModuleData->numParams = eParamNumParams;
 


### PR DESCRIPTION
this relates to issue https://github.com/tehn/aleph/issues/233

paired with `bees` as of https://github.com/tehn/aleph/commit/7c77ecb2a30afac54aaacfff88e286543946edba i'm able to:
- author new scenes (results in the plain module name, i.e. `lines` stored in the scene)
- load old scenes with prefixed module name only, i.e. `aleph-lines`
- load old scenes with prefix and extension in module name, i.e. `aleph-lines.ldr`
