### PR TITLE
rename dummyLedBuffer to defaultLedBuffer

### DIFF
--- a/apps/bees/src/net_monome.c
+++ b/apps/bees/src/net_monome.c
@@ -87,7 +87,7 @@ void net_monome_set_focus(op_monome_t* op_monome, u8 focus) {
   } else {
     if(dev == eDeviceGrid) {
       monome_grid_key_handler = (monome_handler_t)&dummyHandler;
-      monomeLedBuffer = dummyLedBuffer;
+      monomeLedBuffer = defaultLedBuffer;
     } else if(dev == eDeviceArc) {
       monome_ring_enc_handler = (monome_handler_t)&dummyHandler;
     } else {

--- a/utils/avr32_sim/src/monome.c
+++ b/utils/avr32_sim/src/monome.c
@@ -58,8 +58,8 @@ static void read_serial_dummy(void) { return; }
 u8 monomeFrameDirty = 0;
 // a buffer big enough to hold all l data for 256 or arc4
 // each led gets a full byte
-u8 dummyLedBuffer[MONOME_MAX_LED_BYTES];
-u8 *monomeLedBuffer = dummyLedBuffer;
+u8 defaultLedBuffer[MONOME_MAX_LED_BYTES];
+u8 *monomeLedBuffer = defaultLedBuffer;
 
 // global pointers to send functions.
 read_serial_t monome_read_serial = &read_serial_dummy;

--- a/utils/avr32_sim/src/monome.h
+++ b/utils/avr32_sim/src/monome.h
@@ -67,7 +67,7 @@ extern u8 monomeFrameDirty;
 
 // a buffer big enough to hold all led data for 256 or arc4
 // each led gets a full byte
-extern u8 dummyLedBuffer[MONOME_MAX_LED_BYTES];
+extern u8 defaultLedBuffer[MONOME_MAX_LED_BYTES];
 extern u8 *monomeLedBuffer;
 
 //---- function types

--- a/utils/pd/bees_op.c
+++ b/utils/pd/bees_op.c
@@ -216,7 +216,7 @@ void bees_op_setup(void) {
   monome_testbang();
   for(i=0; i<16; i++) {
     for(j=0; j<8; j++) {
-      dummyLedBuffer[i+j*16] = 15-(i/2 + j);
+      defaultLedBuffer[i+j*16] = 15-(i/2 + j);
     }
   }
   monome_update_128_grid(NULL);


### PR DESCRIPTION
once the libavr32 pull-request is merged, we should merge this change immediately & update the submodule to point to monome/libavr32 - currently it points to boqs/libavr32