### PR TITLE
Lines & BEES timebase changes

### DIFF
--- a/apps/bees/src/ops/op_delay.c
+++ b/apps/bees/src/ops/op_delay.c
@@ -96,7 +96,11 @@ void op_delay_in_time (op_delay_t* delay, const io_t v) {
   } else {
     delay->ms = v;
   }
-  delay->timer.ticks = op_to_int(delay->ms);
+  delay->timer.ticks = delay->ms;
+  delay->timer.ticks = delay->timer.ticks << 1;
+  delay->timer.ticks -= delay->timer.ticks >> 7;
+  delay->timer.ticks -= delay->timer.ticks >> 8;
+  delay->timer.ticks -= delay->timer.ticks >> 9;
 }
 
 

--- a/apps/bees/src/ops/op_metro.c
+++ b/apps/bees/src/ops/op_metro.c
@@ -118,7 +118,13 @@ void op_metro_in_period (op_metro_t* metro, const io_t v) {
   } else {
     metro->period = v;
   }
-  metro->timer.ticks = op_to_int(metro->period);
+  // XXX hack alert! the reported time (in milliseconds) seem to be
+  // always off a bit.  Measured them & adding this correction
+  metro->timer.ticks = metro->period;
+  metro->timer.ticks = metro->timer.ticks << 1;
+  metro->timer.ticks -= metro->timer.ticks >> 7;
+  metro->timer.ticks -= metro->timer.ticks >> 8;
+  metro->timer.ticks -= metro->timer.ticks >> 9;
 }
 
 

--- a/apps/bees/src/ops/op_metro.c
+++ b/apps/bees/src/ops/op_metro.c
@@ -192,6 +192,7 @@ u8* op_metro_pickle(op_metro_t* metro, u8* dst) {
   dst = pickle_io(metro->enable, dst);
   dst = pickle_io(metro->period, dst);
   dst = pickle_io(metro->value, dst);
+  dst = pickle_io(metro->divide, dst);
   return dst;
 }
 
@@ -199,6 +200,7 @@ const u8* op_metro_unpickle(op_metro_t* metro, const u8* src) {
   src = unpickle_io(src, &(metro->enable));
   src = unpickle_io(src, &(metro->period));
   src = unpickle_io(src, &(metro->value));
+  src = unpickle_io(src, &(metro->divide));
   if(metro->enable) {
     op_metro_set_timer(metro);
   }

--- a/apps/bees/src/ops/op_metro.c
+++ b/apps/bees/src/ops/op_metro.c
@@ -103,9 +103,10 @@ void op_metro_in_enable	(op_metro_t* metro, const io_t v) {
   if(v > 0) {
     if(metro->enable == 0) {
       metro->enable = OP_ONE;
+      metro->timer.ticks = metro->cacheDivision;
+      metro->tockremainder = metro->cacheRemainder;
       metro->tocks = 0;
       op_metro_set_timer(metro);
-      
     }
   } else {
     if(metro->enable > 0) {
@@ -135,8 +136,11 @@ void op_metro_in_period (op_metro_t* metro, const io_t v) {
   metro->ticklength -= metro->ticklength >> 8;
   metro->ticklength -= metro->ticklength >> 9;
 
-  metro->timer.ticks = metro->ticklength / metro->divide;
-  metro->tockremainder = metro->ticklength % metro->divide;
+  metro->cacheDivision = metro->ticklength / metro->divide;
+  metro->cacheRemainder = metro->ticklength % metro->divide;
+
+  metro->timer.ticks = metro->cacheDivision;
+  metro->tockremainder = metro->cacheRemainder;
   metro->tocks = 0;
 }
 
@@ -155,16 +159,15 @@ void op_metro_in_divide (op_metro_t* metro, const io_t v) {
   else {
     metro->divide = v;
   }
-  /* metro->timer.ticks = metro->ticklength / metro->divide; */
-  /* metro->tockremainder = metro->ticklength % metro->divide; */
-  /* metro->tocks = 0; */
+  metro->cacheDivision = metro->ticklength / metro->divide;
+  metro->cacheRemainder = metro->ticklength % metro->divide;
 }
 
 
 // poll event handler
 void op_metro_poll_handler(void* op) {
   op_metro_t* metro = (op_metro_t*)op;
-  metro->timer.ticks = metro->ticklength / metro->divide;
+  metro->timer.ticks = metro->cacheDivision;
   metro->tockremainder += metro->ticklength % metro->divide;
   if(metro->tockremainder >= metro->divide) {
     metro->tockremainder -= metro->divide;

--- a/apps/bees/src/ops/op_metro.c
+++ b/apps/bees/src/ops/op_metro.c
@@ -13,8 +13,8 @@
 
 //-------------------------------------------------
 //----- descriptor
-static const char* op_metro_instring	= "ENABLE\0 PERIOD\0 VAL\0    ";
-static const char* op_metro_outstring	= "TICK\0   ";
+static const char* op_metro_instring	= "ENABLE\0 PERIOD\0 VAL\0    DIV\0    ";
+static const char* op_metro_outstring	= "TICK\0   TOCK\0   ";
 static const char* op_metro_opstring	= "METRO";
 
 //-------------------------------------------------
@@ -22,12 +22,14 @@ static const char* op_metro_opstring	= "METRO";
 static void op_metro_in_enable	(op_metro_t* metro, const io_t v);
 static void op_metro_in_period	(op_metro_t* metro, const io_t v);
 static void op_metro_in_value	(op_metro_t* metro, const io_t v);
+static void op_metro_in_divide	(op_metro_t* metro, const io_t v);
 
 // array of input functions
-static op_in_fn op_metro_in_fn[3] = {
+static op_in_fn op_metro_in_fn[4] = {
   (op_in_fn)&op_metro_in_enable,
   (op_in_fn)&op_metro_in_period,
   (op_in_fn)&op_metro_in_value,
+  (op_in_fn)&op_metro_in_divide,
 };
 
 
@@ -49,9 +51,10 @@ void op_metro_poll_handler(void* op);
 void op_metro_init(void* op) {
   op_metro_t* metro = (op_metro_t*)op;
   // operator superclass
-  metro->super.numInputs = 3;
-  metro->super.numOutputs = 1;
+  metro->super.numInputs = 4;
+  metro->super.numOutputs = 2;
   metro->outs[0] = -1;
+  metro->outs[1] = -1;
   // polled operator superclass
   metro->op_poll.handler = (poll_handler_t)(&op_metro_poll_handler);
   metro->op_poll.op = metro;
@@ -61,6 +64,7 @@ void op_metro_init(void* op) {
   metro->in_val[0] = &(metro->enable);
   metro->in_val[1] = &(metro->period);
   metro->in_val[2] = &(metro->value);
+  metro->in_val[3] = &(metro->divide);
 
   // pickles
   metro->super.pickle = (op_pickle_fn)(&op_metro_pickle);
@@ -77,6 +81,7 @@ void op_metro_init(void* op) {
   metro->period = op_from_int(125);
   metro->enable = 0;
   metro->value = OP_ONE;
+  metro->divide = OP_ONE;
   // timer (unlinked)
   metro->timer.next = NULL;
 }
@@ -95,15 +100,14 @@ void op_metro_in_enable	(op_metro_t* metro, const io_t v) {
   //  print_dbg("\r\n op_metro_in_enable: 0x");
   //  print_dbg_hex((u32)(v));
 
-  if((v) > 0) {
-    //    print_dbg(" (input value high) ");
+  if(v > 0) {
     if(metro->enable == 0) {
       metro->enable = OP_ONE;
+      metro->tocks = 0;
       op_metro_set_timer(metro);
       
     }
   } else {
-    //    print_dbg(" (input value low) ");
     if(metro->enable > 0) {
       metro->enable = 0;
       op_metro_unset_timer(metro);
@@ -118,13 +122,22 @@ void op_metro_in_period (op_metro_t* metro, const io_t v) {
   } else {
     metro->period = v;
   }
+  op_metro_in_divide(metro, metro->divide);// re-check divide value
+					   // doesn't overload network
+
   // XXX hack alert! the reported time (in milliseconds) seem to be
   // always off a bit.  Measured them & adding this correction
-  metro->timer.ticks = metro->period;
-  metro->timer.ticks = metro->timer.ticks << 1;
-  metro->timer.ticks -= metro->timer.ticks >> 7;
-  metro->timer.ticks -= metro->timer.ticks >> 8;
-  metro->timer.ticks -= metro->timer.ticks >> 9;
+
+  metro->ticklength = metro->period;
+
+  metro->ticklength = metro->ticklength << 1;
+  metro->ticklength -= metro->ticklength >> 7;
+  metro->ticklength -= metro->ticklength >> 8;
+  metro->ticklength -= metro->ticklength >> 9;
+
+  metro->timer.ticks = metro->ticklength / metro->divide;
+  metro->tockremainder = metro->ticklength % metro->divide;
+  metro->tocks = 0;
 }
 
 
@@ -133,13 +146,40 @@ void op_metro_in_value (op_metro_t* metro, const io_t v) {
   metro->value = v;
 }
 
+void op_metro_in_divide (op_metro_t* metro, const io_t v) {
+  if(v < 1) {
+    metro->divide = 1;
+  } else if (v * 5 > metro->period) {
+    // do nothing, so the last effective value is retained
+  }
+  else {
+    metro->divide = v;
+  }
+  /* metro->timer.ticks = metro->ticklength / metro->divide; */
+  /* metro->tockremainder = metro->ticklength % metro->divide; */
+  /* metro->tocks = 0; */
+}
+
 
 // poll event handler
 void op_metro_poll_handler(void* op) {
   op_metro_t* metro = (op_metro_t*)op;
-  //  print_dbg("\r\n op_metro timer callback, value: 0x");
-  //  print_dbg_hex((u32)(metro->value));
-  net_activate(metro, 0, metro->value);
+  metro->timer.ticks = metro->ticklength / metro->divide;
+  metro->tockremainder += metro->ticklength % metro->divide;
+  if(metro->tockremainder >= metro->divide) {
+    metro->tockremainder -= metro->divide;
+    metro->timer.ticks += 1;
+  }
+  metro->tocks += metro->timer.ticks;
+  if(metro->tocks >= metro->ticklength) {
+    /* printf("tick\n"); */
+    metro->tockremainder = metro->ticklength % metro->divide;
+    metro->tocks = 0;
+    net_activate(metro, 0, metro->value);
+  } else {
+    /* printf("tock\n"); */
+    net_activate(metro, 1, metro->value);
+  }
 }
 
 

--- a/apps/bees/src/ops/op_metro.h
+++ b/apps/bees/src/ops/op_metro.h
@@ -27,6 +27,8 @@ typedef struct op_metro_struct {
   u32 tocks;
   u32 tockremainder;
   u32 ticklength;
+  u16 cacheDivision;
+  u16 cacheRemainder;
   // timer data
   softTimer_t timer;
   // polled operator superclass

--- a/apps/bees/src/ops/op_metro.h
+++ b/apps/bees/src/ops/op_metro.h
@@ -16,13 +16,17 @@ typedef struct op_metro_struct {
   op_t super;
   // input pointers
   // enable, period, value
-  volatile io_t* in_val[3];
+  volatile io_t* in_val[4];
   // state variables
   volatile io_t enable;
   volatile io_t period;
   volatile io_t value;
+  volatile io_t divide;
   // outputs
-  op_out_t outs[1];
+  op_out_t outs[2];
+  u32 tocks;
+  u32 tockremainder;
+  u32 ticklength;
   // timer data
   softTimer_t timer;
   // polled operator superclass

--- a/apps/bees/src/ops/op_timer.c
+++ b/apps/bees/src/ops/op_timer.c
@@ -91,7 +91,13 @@ static void op_timer_in_event(op_timer_t* timer, const io_t v) {
   /// for now let's pretend timer interval is 1/1024
   /// reported intervals will be fast by a ratio of 1.024,
   /// in the example above.
-  net_activate(timer, 0, timer->interval);   
+
+  // XXX hack alert! the reported time (in milliseconds) seem to be
+  // always off a bit.  Measured them & adding this correction
+  timer->interval += timer->interval >> 7;
+  timer->interval += timer->interval >> 8;
+  timer->interval += timer->interval >> 9;
+  net_activate(timer, 0, timer->interval >> 1);
 }
 
 

--- a/modules/lines/delayFadeN.c
+++ b/modules/lines/delayFadeN.c
@@ -115,6 +115,9 @@ extern fract32 delayFadeN_next(delayFadeN* dl, fract32 in) {
 // set loop endpoint in seconds
 extern void delayFadeN_set_loop_sec(delayFadeN* dl, fix16 sec, u8 id) {
   u32 samps = sec_to_frames_trunc(sec);
+}
+extern void delayFadeN_set_loop_ms(delayFadeN* dl, fract32 ms, u8 id) {
+  u32 samps = ms * 48;
   buffer_tapN_set_loop(&(dl->tapRd[id]), samps - 1);
   buffer_tapN_set_loop(&(dl->tapWr[id]), samps - 1);
 
@@ -130,6 +133,9 @@ extern void delayFadeN_set_loop_samp(delayFadeN* dl, u32 samps, u8 id) {
 // set delayFadeN in seconds
 extern void delayFadeN_set_delay_sec(delayFadeN* dl, fix16 sec, u8 id) {
   u32 samp = sec_to_frames_trunc(sec);
+}
+extern void delayFadeN_set_delay_ms(delayFadeN* dl, fract32 ms, u8 id) {
+  u32 samp = ms * 48;
   // FIXME (why?)
   // -- something fucks up with i think delay > looptime... infinite wrap or something
   //  buffer_tapN_sync(&(dl->tapRd[id]), &(dl->tapWr[id]), samp);
@@ -164,6 +170,10 @@ extern void delayFadeN_set_pos_read_sec(delayFadeN* dl, fix16 sec, u8 id) {
   u32 samp = sec_to_frames_trunc(sec);
   buffer_tapN_set_pos(&(dl->tapRd[id]), samp);
 }
+extern void delayFadeN_set_pos_read_ms(delayFadeN* dl, fract32 ms, u8 id) {
+  u32 samp = ms * 48;
+  buffer_tapN_set_pos(&(dl->tapRd[id]), samp);
+}
 
 extern void delayFadeN_set_pos_read_samp(delayFadeN* dl, u32 samp, u8 id) {
   buffer_tapN_set_pos(&(dl->tapRd[id]), samp);
@@ -172,6 +182,11 @@ extern void delayFadeN_set_pos_read_samp(delayFadeN* dl, u32 samp, u8 id) {
 // set write pos in seconds
 extern void delayFadeN_set_pos_write_sec(delayFadeN* dl, fix16 sec, u8 id) {
   u32 samp = sec_to_frames_trunc(sec);
+  buffer_tapN_set_pos(&(dl->tapWr[id]), samp);
+}
+
+extern void delayFadeN_set_pos_write_ms(delayFadeN* dl, fract32 ms, u8 id) {
+  u32 samp = 48 * ms;
   buffer_tapN_set_pos(&(dl->tapWr[id]), samp);
 }
 

--- a/modules/lines/delayFadeN.h
+++ b/modules/lines/delayFadeN.h
@@ -49,9 +49,11 @@ extern void delayFadeN_init(delayFadeN* dl, volatile fract32* bufData, u32 frame
 extern fract32 delayFadeN_next(delayFadeN* dl, fract32 in);
 // set loop endpoint in seconds / samples
 extern void delayFadeN_set_loop_sec(delayFadeN* dl, fix16 sec , u8 id );
+extern void delayFadeN_set_loop_ms(delayFadeN* dl, fract32 ms , u8 id );
 extern void delayFadeN_set_loop_samp(delayFadeN* dl, u32 samp , u8 id );
 // set delayFadeN time in seconds / samples
 extern void delayFadeN_set_delay_sec(delayFadeN* dl, fix16 sec, u8 id );
+extern void delayFadeN_set_delay_ms(delayFadeN* dl, fract32 ms, u8 id );
 extern void delayFadeN_set_delay_samp(delayFadeN* dl, u32 samp, u8 id ); 
 // set read head rate
 //extern void delayFadeN_set_rate(delayFadeN* dl, fix16 rate , u8 id );
@@ -63,9 +65,11 @@ extern void delayFadeN_set_write(delayFadeN* dl, u8 write);
 
 // set read pos in seconds / samples
 extern void delayFadeN_set_pos_read_sec(delayFadeN* dl, fix16 sec , u8 id );
+extern void delayFadeN_set_pos_read_ms(delayFadeN* dl, fract32 ms, u8 id );
 extern void delayFadeN_set_pos_read_samp(delayFadeN* dl, u32 samp , u8 id );
 // set write pos in seconds / samples
 extern void delayFadeN_set_pos_write_sec(delayFadeN* dl, fix16 sec , u8 id );
+extern void delayFadeN_set_pos_write_ms(delayFadeN* dl, fract32 ms , u8 id );
 extern void delayFadeN_set_pos_write_samp(delayFadeN* dl, u32 samp , u8 id );
 
 // set read run flag

--- a/modules/lines/lines.c
+++ b/modules/lines/lines.c
@@ -300,7 +300,7 @@ void module_init(void) {
   param_setup( eParamFade0 , 0x100000 );
   param_setup( eParamFade1 , 0x100000 );
 
-  param_setup( 	eParam_loop0,		PARAM_SECONDS_MAX );
+  param_setup( 	eParam_loop0,		10000 );
   param_setup( 	eParam_rMul0,		0x10000 );
   param_setup( 	eParam_rDiv0,		0x10000 );
   param_setup( 	eParam_write0,		FRACT32_MAX );
@@ -308,12 +308,12 @@ void module_init(void) {
   param_setup( 	eParam_pos_write0,		0 );
   param_setup( 	eParam_pos_read0,		0 );
 
-  param_setup( 	eParam_delay0,		0x4000 );
+  param_setup( 	eParam_delay0, 1000 );
 
   param_setup( 	eParam_run_read0, 1 );
   param_setup( 	eParam_run_write0, 1 );
 
-  param_setup( 	eParam_loop1,		PARAM_SECONDS_MAX );
+  param_setup( 	eParam_loop1,		10000 );
   param_setup( 	eParam_rMul1,		0x10000 );
   param_setup( 	eParam_rDiv1,		0x10000 );
   param_setup( 	eParam_write1,		FRACT32_MAX );
@@ -321,7 +321,7 @@ void module_init(void) {
   param_setup( 	eParam_pos_write1,		0 );
   param_setup( 	eParam_pos_read1,		0 );
 
-  param_setup( 	eParam_delay1,		0x4000 );
+  param_setup( 	eParam_delay1, 500);
 
   param_setup( 	eParam_run_read1, 1 );
   param_setup( 	eParam_run_write1, 1 );
@@ -330,6 +330,11 @@ void module_init(void) {
   param_setup( 	eParam_del1_dac1,		PARAM_AMP_6 );
   param_setup( 	eParam_del1_dac2,		PARAM_AMP_12 );
   param_setup( 	eParam_del1_dac3,		PARAM_AMP_6 );
+
+  param_setup( 	eParam_del0_del0,		0 );
+  param_setup( 	eParam_del0_del1,		0 );
+  param_setup( 	eParam_del1_del0,		0 );
+  param_setup( 	eParam_del1_del1,		0 );
 
   param_setup( 	eParam_adc0_dac0,		PARAM_AMP_12 );
   param_setup( 	eParam_adc0_dac1,		PARAM_AMP_12 );

--- a/modules/lines/lines.c
+++ b/modules/lines/lines.c
@@ -300,7 +300,7 @@ void module_init(void) {
   param_setup( eParamFade0 , 0x100000 );
   param_setup( eParamFade1 , 0x100000 );
 
-  param_setup( 	eParam_loop0,		10000 );
+  param_setup( 	eParam_loop0,		10000 << 15 );
   param_setup( 	eParam_rMul0,		0x10000 );
   param_setup( 	eParam_rDiv0,		0x10000 );
   param_setup( 	eParam_write0,		FRACT32_MAX );
@@ -308,12 +308,12 @@ void module_init(void) {
   param_setup( 	eParam_pos_write0,		0 );
   param_setup( 	eParam_pos_read0,		0 );
 
-  param_setup( 	eParam_delay0, 1000 );
+  param_setup( 	eParam_delay0, 1000 << 15);
 
   param_setup( 	eParam_run_read0, 1 );
   param_setup( 	eParam_run_write0, 1 );
 
-  param_setup( 	eParam_loop1,		10000 );
+  param_setup( 	eParam_loop1,		10000 << 15 );
   param_setup( 	eParam_rMul1,		0x10000 );
   param_setup( 	eParam_rDiv1,		0x10000 );
   param_setup( 	eParam_write1,		FRACT32_MAX );
@@ -321,7 +321,7 @@ void module_init(void) {
   param_setup( 	eParam_pos_write1,		0 );
   param_setup( 	eParam_pos_read1,		0 );
 
-  param_setup( 	eParam_delay1, 500);
+  param_setup( 	eParam_delay1, 500 << 15);
 
   param_setup( 	eParam_run_read1, 1 );
   param_setup( 	eParam_run_write1, 1 );

--- a/modules/lines/lines.c
+++ b/modules/lines/lines.c
@@ -336,6 +336,29 @@ void module_init(void) {
   param_setup( 	eParam_del1_del0,		0 );
   param_setup( 	eParam_del1_del1,		0 );
 
+  param_setup(eParam_adc0_del0, PARAM_AMP_6);
+  param_setup(eParam_adc0_del1, PARAM_AMP_6);
+  param_setup(eParam_adc1_del0, 0);
+  param_setup(eParam_adc1_del1, 0);
+  param_setup(eParam_adc2_del0, 0);
+  param_setup(eParam_adc2_del1, 0);
+  param_setup(eParam_adc3_del0, 0);
+  param_setup(eParam_adc3_del1, 0);
+
+  param_setup(eParam_del0_dac0, PARAM_AMP_6);
+  param_setup(eParam_del0_dac1, 0);
+  param_setup(eParam_del0_dac2, 0);
+  param_setup(eParam_del0_dac3, 0);
+  param_setup(eParam_del1_dac0, 0);
+  param_setup(eParam_del1_dac1, PARAM_AMP_6);
+  param_setup(eParam_del1_dac2, 0);
+  param_setup(eParam_del1_dac3, 0);
+
+  param_setup( 	eParam_del1_dac0,		PARAM_AMP_12 );
+  param_setup( 	eParam_del1_dac1,		PARAM_AMP_6 );
+  param_setup( 	eParam_del1_dac2,		PARAM_AMP_12 );
+  param_setup( 	eParam_del1_dac3,		PARAM_AMP_6 );
+
   param_setup( 	eParam_adc0_dac0,		PARAM_AMP_12 );
   param_setup( 	eParam_adc0_dac1,		PARAM_AMP_12 );
   param_setup( 	eParam_adc0_dac2,		PARAM_AMP_12 );

--- a/modules/lines/param_set.c
+++ b/modules/lines/param_set.c
@@ -35,38 +35,38 @@ void module_set_param(u32 idx, ParamValue v) {
     // delay line params
   case eParam_delay0 :
     if( check_fade_rd(0) ) {
-      delayFadeN_set_delay_sec(&(lines[0]), v,  fadeTargetRd[0]);
+      delayFadeN_set_delay_ms(&(lines[0]), v >> 15,  fadeTargetRd[0]);
     }
     break;
   case eParam_delay1 :
     if(check_fade_rd(1)) {
-      delayFadeN_set_delay_sec(&(lines[1]), v,  fadeTargetRd[1]);
+      delayFadeN_set_delay_ms(&(lines[1]), v >> 15,  fadeTargetRd[1]);
     }
     break;
   case eParam_loop0 :
-    delayFadeN_set_loop_sec(&(lines[0]), v, 0);
-    delayFadeN_set_loop_sec(&(lines[0]), v, 1);
+    delayFadeN_set_loop_ms(&(lines[0]), v >> 15, 0);
+    delayFadeN_set_loop_ms(&(lines[0]), v >> 15, 1);
     break;
   case eParam_loop1 :
-    delayFadeN_set_loop_sec(&(lines[1]), v , 0);
-    delayFadeN_set_loop_sec(&(lines[1]), v , 1);
+    delayFadeN_set_loop_ms(&(lines[1]), v >> 15 , 0);
+    delayFadeN_set_loop_ms(&(lines[1]), v >> 15 , 1);
     break;
   case eParam_pos_write0 :
     // check_fade_wr(0);
-    delayFadeN_set_pos_write_sec(&(lines[0]), v,  fadeTargetWr[0]);
+    delayFadeN_set_pos_write_ms(&(lines[0]), v >> 15,  fadeTargetWr[0]);
     break;
   case eParam_pos_write1 :
     // check_fade_wr(1);
-    delayFadeN_set_pos_write_sec(&(lines[1]), v,  fadeTargetWr[1] );
+    delayFadeN_set_pos_write_ms(&(lines[1]), v >> 15,  fadeTargetWr[1] );
     break;
   case eParam_pos_read0 :
     if (check_fade_rd(0) ) {
-      delayFadeN_set_pos_read_sec(&(lines[0]), v,  fadeTargetRd[0]);
+      delayFadeN_set_pos_read_ms(&(lines[0]), v >> 15,  fadeTargetRd[0]);
     }
     break;
   case eParam_pos_read1 :
     if( check_fade_rd(1) ) {
-      delayFadeN_set_pos_read_sec(&(lines[1]), v,  fadeTargetRd[1]);
+      delayFadeN_set_pos_read_ms(&(lines[1]), v >> 15,  fadeTargetRd[1]);
     }
     break;
   case eParam_run_write0 :

--- a/modules/lines/params.h
+++ b/modules/lines/params.h
@@ -48,8 +48,8 @@
 
 // max time in seconds, 16.16
 //// revert until shit gets figured out
-#define PARAM_SECONDS_MAX 0x003c0000
-#define PARAM_SECONDS_RADIX 7
+#define PARAM_SECONDS_MAX 0x7FFFFFFF
+#define PARAM_SECONDS_RADIX 32
 
 /// smoother default
 // about 1ms?

--- a/utils/pd/bees_ops_grid.pd
+++ b/utils/pd/bees_ops_grid.pd
@@ -73,7 +73,7 @@
 #X obj 848 415 BEES_ADD;
 #X obj 866 379 BEES_MUL;
 #X msg 898 346 5;
-#X obj 204 326 tgl 15 0 empty empty empty 17 7 0 10 -262144 -1 -1 1
+#X obj 204 326 tgl 15 0 empty empty empty 17 7 0 10 -262144 -1 -1 0
 1;
 #X obj 610 908 BEES_POLY;
 #X floatatom 591 952 5 0 0 0 - - -, f 5;
@@ -100,6 +100,18 @@
 #X msg 117 489 16;
 #X floatatom 118 685 5 0 0 0 - - -, f 5;
 #X msg 185 519 1;
+#X obj 1154 265 BEES_METRO;
+#X msg 1147 200 1;
+#X msg 1183 198 1000;
+#X msg 1234 198 1;
+#X msg 1272 211 1;
+#X msg 1273 189 2;
+#X msg 1275 164 4;
+#X msg 1274 133 8;
+#X obj 1170 324 bng 15 250 50 0 empty empty empty 17 7 0 10 -262144
+-1 -1;
+#X obj 1224 322 bng 15 250 50 0 empty empty empty 17 7 0 10 -262144
+-1 -1;
 #X connect 2 0 7 0;
 #X connect 2 1 8 0;
 #X connect 2 2 9 0;
@@ -209,3 +221,12 @@
 #X connect 90 0 89 1;
 #X connect 91 0 89 2;
 #X connect 93 0 89 3;
+#X connect 94 0 102 0;
+#X connect 94 1 103 0;
+#X connect 95 0 94 1;
+#X connect 96 0 94 2;
+#X connect 97 0 94 3;
+#X connect 98 0 94 4;
+#X connect 99 0 94 4;
+#X connect 100 0 94 4;
+#X connect 101 0 94 4;


### PR DESCRIPTION
This 'pragmatic' changeset allows to measure the time between BEES button-presses, then set lines loop-lengths accordingly without using unit conversion.  The unit of time becomes 2ms for both BEES & lines, allowing accurate timing of button-presses separated by up to a minute.  Initially measured at by timing ~20 bars of 120bpm metronome with TIMER operator.  Tuned in further by ear referencing AVR32 against blackfin. Looping a drum machine with 2 presses & seeing if the 2nd pass (through loop-point) stays in time with first pass (not through loop-point).

I'm curious whether the required 'fudge-factor' for metro/timer is consistent across alephs, or whether these are special magic numbers that only work for my device!